### PR TITLE
fix importing nested elm modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ if (import.meta.hot) {
       if ('init' in child) {
         modules.push({ path: currentPath, module: child })
       } else {
-        modules = { ...modules, ...findPublicModules(child, currentPath) }
+        modules = [ ...modules, ...findPublicModules(child, currentPath) ]
       }
     })
     return modules


### PR DESCRIPTION
There was what appears to be a typo in the code that was preventing importing of nested elm modules from working. `findPublicModules` was returning an object rather than an array when there were nested public modules which caused code that used it to error with forEach being undefined for example.

This PR changes that code to return an array instead, as I believe was initially intended. I have tested this locally and everything works great now with my nested modules,