### PR TITLE
Fix HMR when imported Elm files are changed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -369,6 +369,17 @@ export const plugin = (): Plugin => {
   return {
     name: 'vite-plugin-elm',
     enforce: 'pre',
+    handleHotUpdate(ctx) {
+      if (!ctx.file.endsWith('.elm')) return
+      let ignoreThisFile = false
+      compilableFiles.forEach((dependencies, file) => {
+        if (dependencies.has(ctx.file)) {
+          console.log(`[vite-plugin-elm] ${viteProjectPath(ctx.file)} was changed -> recompile ${viteProjectPath(file)}.`)
+          ignoreThisFile = true
+        }
+      })
+      return ignoreThisFile ? [] : ctx.modules
+    },
     async transform (_code, id) {
       const isBuild = process.env.NODE_ENV === 'production'
       if (id.endsWith('.elm')) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { relative } from 'path'
 import compiler from 'node-elm-compiler'
 //@ts-ignore
 import { toESModule } from 'elm-esm'
+import { utimes } from 'fs/promises'
 
 const injectHMR = (compiledESM: string, dependencies: string[]): string => `
 ${compiledESM}
@@ -376,6 +377,10 @@ export const plugin = (): Plugin => {
         if (dependencies.has(ctx.file)) {
           console.log(`[vite-plugin-elm] ${viteProjectPath(ctx.file)} was changed -> recompile ${viteProjectPath(file)}.`)
           ignoreThisFile = true
+          // This is a workaround, maybe there is a better way to make vite compile the file?
+          utimes(file, Date.now(), Date.now()).catch(reason => {
+            console.error(`[vite-plugin-elm] error: Could not mark ${file} as modified:`, reason)
+          })
         }
       })
       return ignoreThisFile ? [] : ctx.modules


### PR DESCRIPTION
Hello @hmsk,
this PR fixes issue #3 and triggers HMR for every main Elm file whenever another Elm file down the dependency tree was changed (at least in my small tests :laughing:).

I am not yet satisfied with touching the main elm files in the file system, and will continue looking for a better solution.

Regards,
marc
