### PR TITLE
Add debug option to plugin function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -372,12 +372,16 @@ export const plugin = (opts : { debug: boolean }): Plugin => {
 
   // Enable/disable elm debugger
   let debug : boolean
-  if ((typeof opts !== "undefined") && (typeof opts.debug !== "undefined")) {
-    // User setting
-    debug = opts.debug
+  if (process.env.NODE_ENV === 'production') {
+    // Off in production mode
+    debug = false
   } else {
-    // Environment fallback
-    debug = process.env.NODE_ENV !== 'production'
+    // On/Off in development mode
+    if ((typeof opts !== "undefined") && (typeof opts.debug !== "undefined")) {
+      debug = opts.debug
+    } else {
+      debug = true
+    }
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -372,16 +372,13 @@ export const plugin = (opts : { debug: boolean }): Plugin => {
 
   // Enable/disable elm debugger
   let debug : boolean
-  if (process.env.NODE_ENV === 'production') {
-    // Off in production mode
-    debug = false
+
+  // On/Off given explicit user setting
+  if ((typeof opts !== "undefined") && (typeof opts.debug !== "undefined")) {
+    debug = opts.debug
   } else {
-    // On/Off in development mode
-    if ((typeof opts !== "undefined") && (typeof opts.debug !== "undefined")) {
-      debug = opts.debug
-    } else {
-      debug = true
-    }
+    // Use environment
+    debug = process.env.NODE_ENV !== 'production'
   }
 
   return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -367,8 +367,18 @@ if (import.meta.hot) {
 const trimDebugMessage = (code: string): string => code.replace(/(console\.warn\(\'Compiled in DEBUG mode)/, '// $1')
 const viteProjectPath = (dependency: string) => `/${relative(process.cwd(), dependency)}`
 
-export const plugin = (): Plugin => {
+export const plugin = (opts : { debug: boolean }): Plugin => {
   const compilableFiles: Map<string, Set<string>> = new Map()
+
+  // Enable/disable elm debugger
+  let debug : boolean
+  if ((typeof opts !== "undefined") && (typeof opts.debug !== "undefined")) {
+    // User setting
+    debug = opts.debug
+  } else {
+    // Environment fallback
+    debug = process.env.NODE_ENV !== 'production'
+  }
 
   return {
     name: 'vite-plugin-elm',
@@ -398,7 +408,7 @@ export const plugin = (): Plugin => {
       if (!id.endsWith('.elm')) return
       const isBuild = process.env.NODE_ENV === 'production'
       try {
-        const compiled = await compiler.compileToString([id], { output: '.js', optimize: isBuild, verbose: isBuild, debug: !isBuild })
+        const compiled = await compiler.compileToString([id], { output: '.js', optimize: isBuild, verbose: isBuild, debug })
         const dependencies = await compiler.findAllDependencies(id)
         compilableFiles.set(id, new Set(dependencies))
         const esm = toESModule(compiled)


### PR DESCRIPTION
A possible user setting to disable debugger during development. Admittedly this is not the cleanest code and it perhaps adds complexity to an otherwise straight-forward API.

I'm not sure how the `isBuild` variable is used elsewhere in the code.

closes #14 