### PR TITLE
Defer setting debug flag until NODE_ENV has been set.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -378,7 +378,7 @@ const viteProjectPath = (dependency: string) => `/${relative(process.cwd(), depe
 
 export const plugin = (opts?: { debug?: boolean; optimize?: boolean }): Plugin => {
   const compilableFiles: Map<string, Set<string>> = new Map()
-  const debug = opts?.debug ?? process.env.NODE_ENV !== 'production'
+  const debug = opts?.debug
   const optimize = opts?.optimize
 
   return {
@@ -418,7 +418,7 @@ export const plugin = (opts?: { debug?: boolean; optimize?: boolean }): Plugin =
           output: '.js',
           optimize: typeof optimize === 'boolean' ? optimize : !debug && isBuild,
           verbose: isBuild,
-          debug,
+          debug: debug ?? !isBuild
         })
 
         // Apparently `addWatchFile` may not exist: https://github.com/hmsk/vite-plugin-elm/pull/36


### PR DESCRIPTION
Fixes #120

As described in #120, the default value of the debug flag is evaluated too early (before Vite has finished loading all environment variables).

This defers setting the debug flag until transform is called.
