### PR TITLE
Fix issue with hmr & browser navigation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -283,7 +283,7 @@ if (import.meta.hot) {
           import.meta.hot.invalidate()
         }
 
-        if (typeof elmSymbol("elm$browser$Browser$application") !== "undefined" && typeof elmSymbol("elm$browser$Browser$Navigation") !== "undefined") {
+        if (typeof elmSymbol("elm$browser$Browser$application") !== "undefined") {
           const oldKeyLoc = findNavKey(oldModel)
           const newKeyLoc = findNavKey(newModel)
           let error = null


### PR DESCRIPTION
I have a problem with the following scenario:
- browser is on page A
- an hmr update occurs on this page
- browser navigation gets updated (through `Browser.Navigation.pushUrl`), now the browser is on page B
- I go back on page A (doesn't matter how, pushUrl or browser's back button)

I get flooded with `Uncaught TypeError: can't access property "value" of undefined`.
Apparently `_VirtualDom_applyFacts` crashes [here](https://github.com/elm/virtual-dom/blob/5a5bcf48720bc7d53461b3cd42a9f19f119c5503/src/Elm/Kernel/VirtualDom.js#L496) since `domNode` is undefined.

Now, and I'm not very proud of this :smile: , by visual inspecting elm-hot I found [this line](https://github.com/klazuka/elm-hot/blob/fb2dc49e9b4fa53b51fa6088a1ac7ffa0b72557a/resources/hmr.js#L415) which is different from what [vite-plugin-elm does](https://github.com/hmsk/vite-plugin-elm/blob/bf2bba4d88c7f6b87bad6b951c344af5cf27c1c8/src/index.ts#L286).

It looks like the `elm-hot` version works :shrug: 
