### PR TITLE
Make HMR work on windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export const plugin = (opts?: { debug?: boolean; optimize?: boolean }): Plugin =
 
       const modulesToCompile: ModuleNode[] = []
       compilableFiles.forEach((dependencies, compilableFile) => {
-        if (dependencies.has(file)) {
+        if (dependencies.has(path.normalize(file))) {
           const module = server.moduleGraph.getModuleById(compilableFile)
           if (module) modulesToCompile.push(module)
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { toESModule } from 'elm-esm'
 //@ts-ignore
 import compiler from 'node-elm-compiler'
-import { relative } from 'path'
+import { normalize, relative } from 'path'
 import type { ModuleNode, Plugin } from 'vite'
 import { injectAssets } from './assetsInjector'
 import { injectHMR } from './hmrInjector'
@@ -40,7 +40,7 @@ export const plugin = (opts?: { debug?: boolean; optimize?: boolean }): Plugin =
 
       const modulesToCompile: ModuleNode[] = []
       compilableFiles.forEach((dependencies, compilableFile) => {
-        if (dependencies.has(path.normalize(file))) {
+        if (dependencies.has(normalize(file))) {
           const module = server.moduleGraph.getModuleById(compilableFile)
           if (module) modulesToCompile.push(module)
         }


### PR DESCRIPTION
On windows there are inconsistencies regarding the file paths because of the different path seperator. This leads to the dependencies variable to be something like this:
```
Compilable Files Map(1) {
  '.../src/Main.elm' => Set(1) {     
    '...\\src\\Translations.elm'
  }
}
```

The Set.has call does not take this inconsistency into account and always fails.
The smallest fix I could find is the application of path.normalize. I'm pretty sure this should not break other operating systems and it fixes the problem on windows.