### PR TITLE
Add compilerOptions to config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,11 @@ const parseImportId = (id: string) => {
   }
 }
 
-export const plugin = (opts?: { debug?: boolean; optimize?: boolean }): Plugin => {
+export const plugin = (opts?: { debug?: boolean; optimize?: boolean, compilerOptions?: any }): Plugin => {
   const compilableFiles: Map<string, Set<string>> = new Map()
   const debug = opts?.debug
   const optimize = opts?.optimize
+  const compilerOptions = opts?.compilerOptions
 
   return {
     name: 'vite-plugin-elm',
@@ -92,6 +93,7 @@ export const plugin = (opts?: { debug?: boolean; optimize?: boolean }): Plugin =
           optimize: typeof optimize === 'boolean' ? optimize : !debug && isBuild,
           verbose: isBuild,
           debug: debug ?? !isBuild,
+          ...compilerOptions,
         })
 
         const esm = injectAssets(toESModule(compiled))


### PR DESCRIPTION
Related to https://github.com/hmsk/vite-plugin-elm/issues/2

Instead of adding `pathToElm`, I added a way to pass arbitrary options to the elm compiler.