### PR TITLE
Support importing Elm module as raw string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const viteProjectPath = (dependency: string) => `/${relative(process.cwd(), depe
 const parseImportId = (id: string) => {
   const parsedId = new URL(id, 'file://')
   const pathname = parsedId.pathname
-  const valid = pathname.endsWith('.elm')
+  const valid = pathname.endsWith('.elm') && !parsedId.searchParams.has('raw')
   const withParams = parsedId.searchParams.getAll('with')
 
   return {


### PR DESCRIPTION
A lot of assets can be imported as raw strings in Vite, see https://vitejs.dev/guide/assets.html#importing-asset-as-string. I wanted to use this functionality to automatically build some simple documentation of Elm modules.

Thanks for this nice plugin :-)