### PR TITLE
Add prepare script to help with direct git installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "rm -rf dist && tsc -p .",
     "lint": "eslint . --max-warnings 0",
     "prettier": "prettier --check .",
+    "prepare": "npm run build",
     "build:example": "cd ./example && npm i && npm run build",
     "test-server:dev": "cd ./example && npm run dev -- --port 8936",
     "test-server:preview": "cd ./example && npm run preview -- --port 8938",


### PR DESCRIPTION
This "prepare" script is automatically run as part of publishing. More importantly, when an `npm` package is installed by referencing its `git` repository, the prepare script is run after downloading the repository and before packaging & installing the results to the `node_modules` directory.

Without this, using `hmsk/vite-plugin-elm#main` to install a pre-release version will not work because there will be no `dist` directory in the node_modules install location. With this, that type of install works.

ref. https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts