### PR TITLE
allow Vite 5 as a peer dependency

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -15,7 +15,7 @@
       }
     },
     "..": {
-      "version": "2.8.0",
+      "version": "2.9.0-beta.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26,19 +26,19 @@
         "node-elm-compiler": "5.0.6"
       },
       "devDependencies": {
-        "@types/node": "18.16.1",
-        "@typescript-eslint/eslint-plugin": "5.59.2",
-        "@typescript-eslint/parser": "5.59.2",
-        "cypress": "12.11.0",
-        "eslint": "8.39.0",
-        "eslint-config-prettier": "8.8.0",
+        "@types/node": "18.18.9",
+        "@typescript-eslint/eslint-plugin": "6.7.0",
+        "@typescript-eslint/parser": "6.7.0",
+        "cypress": "12.17.4",
+        "eslint": "8.47.0",
+        "eslint-config-prettier": "9.0.0",
         "npm-run-all": "4.1.5",
-        "prettier": "2.8.8",
-        "typescript": "5.0.4",
-        "vite": "4.3.3"
+        "prettier": "3.1.0",
+        "typescript": "5.1.6",
+        "vite": "4.5.1"
       },
       "peerDependencies": {
-        "vite": "^4.0.0 || ^3.0.0 || ^2.0.0"
+        "vite": "^5.0.0 || ^4.0.0 || ^3.0.0 || ^2.0.0"
       }
     },
     "../node_modules/@colors/colors": {
@@ -5611,21 +5611,21 @@
     "vite-plugin-elm": {
       "version": "file:..",
       "requires": {
-        "@types/node": "18.16.1",
-        "@typescript-eslint/eslint-plugin": "5.59.2",
-        "@typescript-eslint/parser": "5.59.2",
+        "@types/node": "18.18.9",
+        "@typescript-eslint/eslint-plugin": "6.7.0",
+        "@typescript-eslint/parser": "6.7.0",
         "acorn": "^8.0.0",
         "acorn-walk": "^8.0.0",
-        "cypress": "12.11.0",
+        "cypress": "12.17.4",
         "elm-esm": "1.1.4",
-        "eslint": "8.39.0",
-        "eslint-config-prettier": "8.8.0",
+        "eslint": "8.47.0",
+        "eslint-config-prettier": "9.0.0",
         "find-up": "^5.0.0",
         "node-elm-compiler": "5.0.6",
         "npm-run-all": "4.1.5",
-        "prettier": "2.8.8",
-        "typescript": "5.0.4",
-        "vite": "4.3.3"
+        "prettier": "3.1.0",
+        "typescript": "5.1.6",
+        "vite": "4.5.1"
       },
       "dependencies": {
         "@colors/colors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-elm",
-  "version": "2.9.0-beta.1",
+  "version": "2.9.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-elm",
-      "version": "2.9.0-beta.1",
+      "version": "2.9.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.0.0",
@@ -25,10 +25,10 @@
         "npm-run-all": "4.1.5",
         "prettier": "3.1.0",
         "typescript": "5.1.6",
-        "vite": "4.4.9"
+        "vite": "4.5.1"
       },
       "peerDependencies": {
-        "vite": "^4.0.0 || ^3.0.0 || ^2.0.0"
+        "vite": "^5.0.0 || ^4.0.0 || ^3.0.0 || ^2.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4620,9 +4620,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -7962,9 +7962,9 @@
       }
     },
     "vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-elm",
-  "version": "2.9.0-beta.1",
+  "version": "2.9.0-beta.2",
   "description": "Compile Elm with vite",
   "main": "dist/index.js",
   "files": [
@@ -68,9 +68,9 @@
     "npm-run-all": "4.1.5",
     "prettier": "3.1.0",
     "typescript": "5.1.6",
-    "vite": "4.4.9"
+    "vite": "4.5.1"
   },
   "peerDependencies": {
-    "vite": "^4.0.0 || ^3.0.0 || ^2.0.0"
+    "vite": "^5.0.0 || ^4.0.0 || ^3.0.0 || ^2.0.0"
   }
 }


### PR DESCRIPTION
Hello! This PR fixes should fix this [issue](https://github.com/hmsk/vite-plugin-elm/issues/574) preventing Vite 5 from being used as a peer dependency with `vite-plugin-elm`.

I believe v5 should just work out of the box as a peer dependency, it just needs to be allowed in `package.json`. Additionally, I upgraded vite as a dependency to the latest v4 version.

cypress tests passed for me and I was able to use this successfully in an existing project that uses the plugin

This is my first PR for this plugin, so please let me know if I missed anything or anything could be improved. Thanks!

