### PR TITLE
Add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "dist"
   ],
+  "types": "./dist/index.d.ts",
   "scripts": {
     "dev": "tsc -w -p .",
     "build": "rm -rf dist && tsc -p .",


### PR DESCRIPTION
Without it, Typescript trips up when you use vite-plugin-elm, saying it cannot find its type declarations.
It looks for the d.ts entrypoint in ./index.d.ts but cannot find it, since it is in ./dist/index.d.ts instead.