### PR TITLE
Fix import-analysis warnings

### DIFF
--- a/src/hmrInjector.ts
+++ b/src/hmrInjector.ts
@@ -45,7 +45,7 @@ if (import.meta.hot) {
 
   import.meta.hot.accept()
   import.meta.hot.accept([
-    "${dependencies.join('", "')}"
+    ${dependencies.join('", "')}
   ], () => { console.log("[vite-plugin-elm] Dependency is updated") })
 
   import.meta.hot.on('hot-update-dependents', (data) => {

--- a/src/hmrInjector.ts
+++ b/src/hmrInjector.ts
@@ -45,7 +45,7 @@ if (import.meta.hot) {
 
   import.meta.hot.accept()
   import.meta.hot.accept([
-    ${dependencies.join('", "')}
+    ${dependencies.length < 1 ? '' : '"' + dependencies.join('", "') + '"'}
   ], () => { console.log("[vite-plugin-elm] Dependency is updated") })
 
   import.meta.hot.on('hot-update-dependents', (data) => {


### PR DESCRIPTION
This should fix https://github.com/hmsk/vite-plugin-elm/issues/806

I don't really get why I have to return different things from resolveId depending on if the source came
from an elm importer or from somewhere else (js/ts).
Maybe you have more context of the rest of the source code and can explain/refactor/give me a hint.

This works for me in https://gitlab.com/andreasewering/safari-zone which is a pretty large elm codebase so I hope it works in general 🤞 