### PR TITLE
Manually keep track of importers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,9 +70,18 @@ export const plugin = (userOptions: Parameters<typeof parseOptions>[0] = {}): Pl
       const accompanies = await (() => {
         if (withParams.length > 0) {
           const importers = importerMap.get(id) || new Set()
-          // We assume that the first importer is the main entry point for the Elm file, and that it is only
-          const importer = importers.size > 0 ? Array.from(importers)[0] : ''
-          const resolveAccompany = async (accompany: string) => (await this.resolve(accompany, importer))?.id ?? ''
+          // We assume that the first importer is the main entry point for the Elm file, and that it is the only one
+          const importer = Array.from(importers)[0]
+          const resolveAccompany = async (accompany: string) => {
+            if (importer) {
+              return (await this.resolve(accompany, importer))?.id ?? '';
+            } else if (accompany.startsWith('./') || accompany.startsWith('../')) {
+              // Resolve relative to the elm file's directory
+              return (await this.resolve(accompany, pathname))?.id ?? '';
+            } else {
+              return (await this.resolve(accompany))?.id ?? '';
+            }
+          };
           return Promise.all(withParams.map(resolveAccompany))
         } else {
           return Promise.resolve([])

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ const parseImportId = (id: string) => {
 export const plugin = (userOptions: Parameters<typeof parseOptions>[0] = {}): Plugin => {
   const options = parseOptions(userOptions)
   const compilableFiles: Map<string, Set<string>> = new Map()
+  const importerMap = new Map<string, Set<string>>() // importee -> Set(importers)
 
   return {
     name: 'vite-plugin-elm',
@@ -53,18 +54,24 @@ export const plugin = (userOptions: Parameters<typeof parseOptions>[0] = {}): Pl
         return modules
       }
     },
+    resolveId(id, importer) {
+      if (importer) {
+        if (!importerMap.has(id)) {
+          importerMap.set(id, new Set())
+        }
+        importerMap.get(id)!.add(importer)
+      }
+      return null // Let other plugins handle resolution
+    },
     async load(id) {
       const { valid, pathname, withParams } = parseImportId(id)
       if (!valid) return
 
       const accompanies = await (() => {
         if (withParams.length > 0) {
-          const importTree = this.getModuleIds()
-          let importer = ''
-          for (const moduleId of importTree) {
-            if (moduleId === id) break
-            importer = moduleId
-          }
+          const importers = importerMap.get(id) || new Set()
+          // We assume that the first importer is the main entry point for the Elm file, and that it is only
+          const importer = importers.size > 0 ? Array.from(importers)[0] : ''
           const resolveAccompany = async (accompany: string) => (await this.resolve(accompany, importer))?.id ?? ''
           return Promise.all(withParams.map(resolveAccompany))
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,14 +74,14 @@ export const plugin = (userOptions: Parameters<typeof parseOptions>[0] = {}): Pl
           const importer = Array.from(importers)[0]
           const resolveAccompany = async (accompany: string) => {
             if (importer) {
-              return (await this.resolve(accompany, importer))?.id ?? '';
+              return (await this.resolve(accompany, importer))?.id ?? ''
             } else if (accompany.startsWith('./') || accompany.startsWith('../')) {
               // Resolve relative to the elm file's directory
-              return (await this.resolve(accompany, pathname))?.id ?? '';
+              return (await this.resolve(accompany, pathname))?.id ?? ''
             } else {
-              return (await this.resolve(accompany))?.id ?? '';
+              return (await this.resolve(accompany))?.id ?? ''
             }
-          };
+          }
           return Promise.all(withParams.map(resolveAccompany))
         } else {
           return Promise.resolve([])


### PR DESCRIPTION
The existing implementation assumed a stable order in the `importTree`, which is not given. Sometimes the `importer` that was used contained a query param `?` in the id, which prevented `this.resolve()` from resolving correctly, leading to an error such the following. We combine multiple Elm apps into on big bundle to share the same Elm runtime.

```
[vite-plugin-elm] Could not load /home/runner/work/repo/src/elm/Apps.elm?with=@app/elm/App1.elm&with=@app/elm/App2.elm&with=@app/elm/App3.elm (imported by ../../src/js/elm-apps.js): ENOENT: no such file or directory, open '@app/elm/App1.elm'
```